### PR TITLE
feat(config): set up inheritance for config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ global:
     team_id: "team"
     project_config:
         manual_production_deployment: false # Variable to help with setting up manual deployments in Terraform
+        serverless_function_region: "fra1"
         environment_variables:
             - key: CUSTOM_GLOBAL_ENVIRONMENT_VARIABLE
               value: custom
@@ -33,7 +34,12 @@ sites:
         - name: my-component
           vercel: # Override defaults on component level
             project_config:
+                name: "my-vercel-project"
+                framework: "nextjs"
                 manual_production_deployment: true
+                git_repository:
+                  type: "github"
+                  repo: "mach-composer/my-vercel-project"
                 environment_variables:
                     - key: CUSTOM_SITE_SPECIFIC_ENVIRONMENT_VARIABLE
                       value: custom

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/mach-composer/mach-composer-plugin-vercel
 go 1.19
 
 require (
+	github.com/google/go-cmp v0.5.8
 	github.com/mach-composer/mach-composer-plugin-helpers v0.0.1
 	github.com/mach-composer/mach-composer-plugin-sdk v0.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.8.1
+	golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a
 )
 
 require (
@@ -16,7 +18,6 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/flosch/pongo2/v5 v5.0.0 // indirect
 	github.com/golang/protobuf v1.3.4 // indirect
-	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/go-hclog v1.3.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.6 // indirect
@@ -31,7 +32,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 	google.golang.org/grpc v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
 github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/hashicorp/go-hclog v1.3.1 h1:vDwF1DFNZhntP4DAjuTpOw3uEgMUpXh1pB5fW9DqHpo=
@@ -80,6 +82,8 @@ github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY
 github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a h1:tlXy25amD5A7gOfbXdqCGN5k8ESEed/Ee1E5RcrYnqU=
+golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -102,6 +106,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/internal/config.go
+++ b/internal/config.go
@@ -40,8 +40,66 @@ func (c *VercelConfig) extendConfig(o *VercelConfig) *VercelConfig {
 }
 
 type ProjectConfig struct {
+	Name                       string                       `mapstructure:"name"`
+	Framework                  string                       `mapstructure:"framework"`
 	ManualProductionDeployment bool                         `mapstructure:"manual_production_deployment"`
+	ServerlessFunctionRegion   string                       `mapstructure:"serverless_function_region"`
 	EnvironmentVariables       []ProjectEnvironmentVariable `mapstructure:"environment_variables"`
+	GitRepository              GitRepository                `mapstructure:"git_repository"`
+	BuildCommand               string                       `mapstructure:"build_command"`
+	RootDirectory              string                       `mapstructure:"root_directory"`
+}
+
+func (c *ProjectConfig) extendConfig(o *ProjectConfig) *ProjectConfig {
+	if o != nil && o != (&ProjectConfig{}) {
+		cfg := &ProjectConfig{
+			ManualProductionDeployment: o.ManualProductionDeployment,
+			EnvironmentVariables:       o.EnvironmentVariables,
+		}
+
+		if c.Name != o.Name {
+			cfg.Name = c.Name
+		}
+
+		if c.Framework != o.Framework {
+			cfg.Framework = c.Framework
+		}
+
+		if c.ServerlessFunctionRegion != o.ServerlessFunctionRegion {
+			cfg.ServerlessFunctionRegion = c.ServerlessFunctionRegion
+		}
+
+		if c.BuildCommand != o.BuildCommand {
+			cfg.BuildCommand = c.BuildCommand
+		}
+
+		if c.RootDirectory != o.RootDirectory {
+			cfg.RootDirectory = c.RootDirectory
+		}
+
+		if c.ManualProductionDeployment != o.ManualProductionDeployment {
+			cfg.ManualProductionDeployment = c.ManualProductionDeployment
+		}
+
+		if c.GitRepository != o.GitRepository {
+			cfg.GitRepository = c.GitRepository
+		}
+
+		if !slices.EqualFunc(c.EnvironmentVariables, o.EnvironmentVariables, EqualEnvironmentVariables) {
+			// Append missing environment variables
+			cfg.EnvironmentVariables = append(cfg.EnvironmentVariables, c.EnvironmentVariables...)
+			// TODO: Update environment variables that exist in both configs with values of the site config
+
+		}
+		return cfg
+	}
+
+	return c
+}
+
+type GitRepository struct {
+	Type string `mapstructure:"type"`
+	Repo string `mapstructure:"repo"`
 }
 
 type ProjectEnvironmentVariable struct {
@@ -58,27 +116,4 @@ func (c *ProjectEnvironmentVariable) DisplayEnvironments() string {
 
 func EqualEnvironmentVariables(c, o ProjectEnvironmentVariable) bool {
 	return c.Key == o.Key && c.Value == o.Value && slices.Equal(c.Environment, o.Environment)
-}
-
-func (c *ProjectConfig) extendConfig(o *ProjectConfig) *ProjectConfig {
-	if o != nil && o != (&ProjectConfig{}) {
-		cfg := &ProjectConfig{
-			ManualProductionDeployment: o.ManualProductionDeployment,
-			EnvironmentVariables:       o.EnvironmentVariables,
-		}
-
-		if c.ManualProductionDeployment != o.ManualProductionDeployment {
-			cfg.ManualProductionDeployment = c.ManualProductionDeployment
-		}
-
-		if !slices.EqualFunc(c.EnvironmentVariables, o.EnvironmentVariables, EqualEnvironmentVariables) {
-			// Append missing environment variables
-			cfg.EnvironmentVariables = append(cfg.EnvironmentVariables, c.EnvironmentVariables...)
-			// TODO: Update environment variables that exist in both configs with values of the site config
-
-		}
-		return cfg
-	}
-
-	return c
 }

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -131,6 +131,11 @@ func (p *VercelPlugin) RenderTerraformComponent(site string, component string) (
 
 	template := `
 		vercel_team_id = {{ .TeamID|printf "%q" }}
+		name = {{ .ProjectConfig.Name|printf "%q" }}
+		framework = {{ .ProjectConfig.Framework|printf "%q" }}
+		build_command = {{ .ProjectConfig.BuildCommand|printf "%q" }}
+		root_directory = {{ .ProjectConfig.RootDirectory|printf "%q" }}
+		serverless_function_region = {{ .ProjectConfig.ServerlessFunctionRegion|printf "%q" }}
 		manual_production_deployment = {{ .ProjectConfig.ManualProductionDeployment }}
 		environment_variables = [{{range .ProjectConfig.EnvironmentVariables }}
 			{

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -137,6 +137,10 @@ func (p *VercelPlugin) RenderTerraformComponent(site string, component string) (
 		root_directory = {{ .ProjectConfig.RootDirectory|printf "%q" }}
 		serverless_function_region = {{ .ProjectConfig.ServerlessFunctionRegion|printf "%q" }}
 		manual_production_deployment = {{ .ProjectConfig.ManualProductionDeployment }}
+		git_repository = {
+			type = {{ .ProjectConfig.GitRepository.Type|printf "%q" }}
+			repo = {{ .ProjectConfig.GitRepository.Repo|printf "%q" }}
+		}
 		environment_variables = [{{range .ProjectConfig.EnvironmentVariables }}
 			{
 				key = {{ .Key|printf "%q" }}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -12,6 +12,11 @@ func TestSetVercelConfig(t *testing.T) {
 		"team_id":   "test-team",
 		"api_token": "test-token",
 		"project_config": map[string]any{
+			"name":                         "test-project",
+			"framework":                    "nextjs",
+			"serverless_function_region":   "iad1",
+			"build_command":                "next build",
+			"root_directory":               "./my-project",
 			"manual_production_deployment": true,
 			"environment_variables": []map[string]any{
 				{"key": "TEST_ENVIRONMENT_VARIABLE", "value": "testing"},
@@ -36,6 +41,11 @@ func TestSetVercelConfig(t *testing.T) {
 
 	component, err := plugin.RenderTerraformComponent("my-site", "test-component")
 	require.NoError(t, err)
+	assert.Contains(t, component.Variables, "name = \"test-project\"")
+	assert.Contains(t, component.Variables, "framework = \"nextjs\"")
+	assert.Contains(t, component.Variables, "serverless_function_region = \"iad1\"")
+	assert.Contains(t, component.Variables, "build_command = \"next build\"")
+	assert.Contains(t, component.Variables, "root_directory = \"./my-project\"")
 	assert.Contains(t, component.Variables, "vercel_team_id = \"test-team\"")
 	assert.Contains(t, component.Variables, "manual_production_deployment = true")
 

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -18,6 +18,10 @@ func TestSetVercelConfig(t *testing.T) {
 			"build_command":                "next build",
 			"root_directory":               "./my-project",
 			"manual_production_deployment": true,
+			"git_repository": map[string]any{
+				"type": "github",
+				"repo": "mach-composer/my-project",
+			},
 			"environment_variables": []map[string]any{
 				{"key": "TEST_ENVIRONMENT_VARIABLE", "value": "testing"},
 				{"key": "TEST_ENVIRONMENT_VARIABLE_2", "value": "testing", "environment": []string{"production", "preview"}},
@@ -48,6 +52,8 @@ func TestSetVercelConfig(t *testing.T) {
 	assert.Contains(t, component.Variables, "root_directory = \"./my-project\"")
 	assert.Contains(t, component.Variables, "vercel_team_id = \"test-team\"")
 	assert.Contains(t, component.Variables, "manual_production_deployment = true")
+	assert.Contains(t, component.Variables, "type = \"github\"")
+	assert.Contains(t, component.Variables, "repo = \"mach-composer/my-project\"")
 
 	// Test environment variables
 

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -71,6 +71,7 @@ func TestInheritEnvironmentVariables(t *testing.T) {
 			"manual_production_deployment": true,
 			"environment_variables": []map[string]any{
 				{"key": "TEST_ENVIRONMENT_VARIABLE", "value": "testing"},
+				{"key": "TEST_EXTEND_VARIABLE", "value": "test", "environment": []string{"production"}},
 			},
 		},
 	}
@@ -82,6 +83,7 @@ func TestInheritEnvironmentVariables(t *testing.T) {
 			"manual_production_deployment": true,
 			"environment_variables": []map[string]any{
 				{"key": "TEST_ENVIRONMENT_VARIABLE_2", "value": "testing", "environment": []string{"production", "preview"}},
+				{"key": "TEST_EXTEND_VARIABLE", "value": "testing", "environment": []string{"production", "preview", "development"}},
 			},
 		},
 	}
@@ -100,5 +102,47 @@ func TestInheritEnvironmentVariables(t *testing.T) {
 
 	assert.Contains(t, component.Variables, "environment = [\"development\", \"preview\", \"production\"]")
 	assert.Contains(t, component.Variables, "environment = [\"production\", \"preview\"]")
+
+	assert.Contains(t, component.Variables, "environment")
+}
+
+func TestExtendEnvironmentVariables(t *testing.T) {
+	globalData := map[string]any{
+		"team_id":   "test-team",
+		"api_token": "test-token",
+		"project_config": map[string]any{
+			"manual_production_deployment": true,
+			"environment_variables": []map[string]any{
+				{"key": "TEST_EXTEND_VARIABLE", "value": "test", "environment": []string{"production"}},
+			},
+		},
+	}
+
+	siteData := map[string]any{
+		"team_id":   "test-team",
+		"api_token": "test-token",
+		"project_config": map[string]any{
+			"manual_production_deployment": true,
+			"environment_variables": []map[string]any{
+				{"key": "TEST_EXTEND_VARIABLE", "value": "testing", "environment": []string{"production", "preview", "development"}},
+			},
+		},
+	}
+
+	plugin := NewVercelPlugin()
+
+	err := plugin.SetGlobalConfig(globalData)
+	require.NoError(t, err)
+
+	err = plugin.SetSiteConfig("my-site", siteData)
+	require.NoError(t, err)
+
+	// Test whether environment variables get extended
+	component, err := plugin.RenderTerraformComponent("my-site", "test-component")
+	require.NoError(t, err)
+
+	// Should only contain the site extended variable content
+	assert.Contains(t, component.Variables, "environment = [\"production\", \"preview\", \"development\"]")
+	assert.Contains(t, component.Variables, "value = \"testing\"")
 
 }


### PR DESCRIPTION
One of the main features is that a site should properly inherit global
values and override these where necessary.
These can range from simple value overrides to changing environments
within a site for a globally set environment variable.

- [x] Test and potentially fix global/project level overrides
- [x] Set up appending of environment variables
- [x] Allow overriding of value/environments for a given environment variable
