### PR TITLE
fix(plugin): add support for sops secrets and variables

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -177,30 +177,30 @@ func (p *VercelPlugin) RenderTerraformComponent(site string, component string) (
 	}
 
 	template := `
-		vercel_team_id = {{ .TeamID|printf "%q" }}
-		vercel_project_name = {{ .ProjectConfig.Name|printf "%q" }}
-		vercel_project_framework = {{ .ProjectConfig.Framework|printf "%q" }}
-		vercel_project_build_command = {{ .ProjectConfig.BuildCommand|printf "%q" }}
-		vercel_project_root_directory = {{ .ProjectConfig.RootDirectory|printf "%q" }}
-		vercel_project_serverless_function_region = {{ .ProjectConfig.ServerlessFunctionRegion|printf "%q" }}
-		vercel_project_manual_production_deployment = {{ .ProjectConfig.ManualProductionDeployment }}
+		{{ renderProperty "vercel_team_id" .TeamID }}
+		{{ renderProperty "vercel_project_name" .ProjectConfig.Name }}
+		{{ renderProperty "vercel_project_framework" .ProjectConfig.Framework }}
+		{{ renderProperty "vercel_project_build_command" .ProjectConfig.BuildCommand }}
+		{{ renderProperty "vercel_project_root_directory" .ProjectConfig.RootDirectory }}
+		{{ renderProperty "vercel_project_serverless_function_region" .ProjectConfig.ServerlessFunctionRegion }}
+		{{ renderProperty "vercel_project_manual_production_deployment" .ProjectConfig.ManualProductionDeployment }}
 		vercel_project_git_repository = {
-			type = {{ .ProjectConfig.GitRepository.Type|printf "%q" }}
-			repo = {{ .ProjectConfig.GitRepository.Repo|printf "%q" }}
+			{{ renderProperty "type" .ProjectConfig.GitRepository.Type }}
+			{{ renderProperty "repo" .ProjectConfig.GitRepository.Repo }}
 		}
 		vercel_project_environment_variables = [{{range .ProjectConfig.EnvironmentVariables }}
 			{
-				key = {{ .Key|printf "%q" }}
-				value = {{ .Value|printf "%q" }}
+				{{ renderProperty "key" .Key }}
+				{{ renderProperty "value" .Value }}
 				{{ .DisplayEnvironments }}
 			},{{end}}
 		]
 		vercel_project_domains = [{{range .ProjectConfig.ProjectDomains }}
 			{
-				domain = {{ .Domain|printf "%q" }}
-				git_branch = {{ .GitBranch|printf "%q" }}
-				redirect = {{ .Redirect|printf "%q" }}
-				redirect_status_code = {{ .RedirectStatusCode }}
+				{{ renderProperty "domain" .Domain }}
+				{{ renderProperty "git_branch" .GitBranch }}
+				{{ renderProperty "redirect" .Redirect}}
+				{{ renderProperty "redirect_status_code" .RedirectStatusCode }}
 			},{{end}}
 		]
 	`

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -163,7 +163,7 @@ func (p *VercelPlugin) RenderTerraformResources(site string) (string, error) {
 
 	resourceTemplate := `
 		provider "vercel" {
-			api_token = {{ .APIToken|printf "%q" }}
+			{{ renderProperty "api_token" .APIToken }}
 		}
 	`
 

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -33,7 +33,7 @@ func TestSetVercelConfig(t *testing.T) {
 
 	data := map[string]any{
 		"team_id":   "test-team",
-		"api_token": "test-token",
+		"api_token": "${sops.data.output[\"api_token\"]}",
 		"project_config": map[string]any{
 			"name":                         "test-project",
 			"framework":                    "nextjs",
@@ -62,7 +62,7 @@ func TestSetVercelConfig(t *testing.T) {
 
 	result, err := plugin.RenderTerraformResources("my-site")
 	require.NoError(t, err)
-	assert.Contains(t, result, "api_token = \"test-token\"")
+	assert.Contains(t, result, `api_token = sops.data.output["api_token"]`)
 
 	component, err := plugin.RenderTerraformComponent("my-site", "test-component")
 	require.NoError(t, err)


### PR DESCRIPTION
- fix(plugin): use renderProperty to fix SOPS variables being incorrectly parsed
- test(plugin): add testcase for using sops for api_token

Because I wrapped all the properties in strings it would incorrectly parse sops variables breaking HCL.
Switched to using the default helpers, `renderProperty` in this case to properly handle this use case.
