### PR TITLE
feat: add ignore_command

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -62,6 +62,7 @@ type ProjectConfig struct {
 	EnvironmentVariables          []ProjectEnvironmentVariable `mapstructure:"environment_variables"`
 	GitRepository                 GitRepository                `mapstructure:"git_repository"`
 	BuildCommand                  string                       `mapstructure:"build_command"`
+	IgnoreCommand                 string                       `mapstructure:"ignore_command"`
 	RootDirectory                 string                       `mapstructure:"root_directory"`
 	ProjectDomains                []ProjectDomain              `mapstructure:"domains"`
 	ProtectionBypassForAutomation bool                         `mapstructure:"protection_bypass_for_automation"`
@@ -76,6 +77,7 @@ func (c *ProjectConfig) extendConfig(o *ProjectConfig) *ProjectConfig {
 			Framework:                     o.Framework,
 			ServerlessFunctionRegion:      o.ServerlessFunctionRegion,
 			BuildCommand:                  o.BuildCommand,
+			IgnoreCommand:                 o.IgnoreCommand,
 			RootDirectory:                 o.RootDirectory,
 			ManualProductionDeployment:    o.ManualProductionDeployment,
 			EnvironmentVariables:          o.EnvironmentVariables,
@@ -100,6 +102,10 @@ func (c *ProjectConfig) extendConfig(o *ProjectConfig) *ProjectConfig {
 
 		if c.BuildCommand != "" {
 			cfg.BuildCommand = c.BuildCommand
+		}
+
+		if c.IgnoreCommand != "" {
+			cfg.IgnoreCommand = c.IgnoreCommand
 		}
 
 		if c.RootDirectory != "" {

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -182,6 +182,7 @@ func (p *VercelPlugin) RenderTerraformComponent(site string, component string) (
 		{{ renderProperty "vercel_project_name" .ProjectConfig.Name }}
 		{{ renderProperty "vercel_project_framework" .ProjectConfig.Framework }}
 		{{ renderProperty "vercel_project_build_command" .ProjectConfig.BuildCommand }}
+		{{ renderProperty "vercel_project_ignore_command" .ProjectConfig.IgnoreCommand }}
 		{{ renderProperty "vercel_project_root_directory" .ProjectConfig.RootDirectory }}
 		{{ renderProperty "vercel_project_serverless_function_region" .ProjectConfig.ServerlessFunctionRegion }}
 		{{ renderProperty "vercel_project_manual_production_deployment" .ProjectConfig.ManualProductionDeployment }}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -40,6 +40,7 @@ func TestSetVercelConfig(t *testing.T) {
 			"framework":                    "nextjs",
 			"serverless_function_region":   "iad1",
 			"build_command":                "next build",
+			"ignore_command":               "if [ $VERCEL_ENV == 'production' ]; then exit 1; else exit 0; fi",
 			"root_directory":               "./my-project",
 			"manual_production_deployment": true,
 			"git_repository": map[string]any{
@@ -80,6 +81,7 @@ func TestSetVercelConfig(t *testing.T) {
 	assert.Contains(t, component.Variables, "framework = \"nextjs\"")
 	assert.Contains(t, component.Variables, "serverless_function_region = \"iad1\"")
 	assert.Contains(t, component.Variables, "build_command = \"next build\"")
+	assert.Contains(t, component.Variables, "ignore_command = \"if [ $VERCEL_ENV == 'production' ]; then exit 1; else exit 0; fi\"")
 	assert.Contains(t, component.Variables, "root_directory = \"./my-project\"")
 	assert.Contains(t, component.Variables, "vercel_team_id = \"test-team\"")
 	assert.Contains(t, component.Variables, "manual_production_deployment = true")


### PR DESCRIPTION
Adds the ability to add an 'ignore_command' through mach-composer.

@see https://registry.terraform.io/providers/vercel/vercel/latest/docs/resources/project#ignore_command

![Screenshot 2024-02-14 at 15 31 07](https://github.com/mach-composer/mach-composer-plugin-vercel/assets/248906/d667285d-efe6-4205-9e57-6c2d060d61d3)
